### PR TITLE
Fix JS errors due to bad indicies from core code.

### DIFF
--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -67,8 +67,9 @@ function IslandoraBookReader(settings) {
    *   The PID the given page repersents.
    */
   IslandoraBookReader.prototype.getPID = function(index) {
-    if (typeof this.getPage(index) != 'undefined') {
-      return this.getPage(index).pid;
+    var page = this.getPage(index);
+    if (typeof page != 'undefined') {
+      return page.pid;
     }
   }
 
@@ -88,26 +89,28 @@ function IslandoraBookReader(settings) {
     var dimensions = { width: 0, height: 0 };
     var page = this.getPage(index);
 
-    // If we don't have one or the other, make a query out to Djatoka.
-    if (typeof page.width == 'undefined' || typeof page.height == 'undefined') {
-      var pid = page.pid;
-      if(typeof pid == 'undefined') {
-        return dimensions;
+    if (typeof page != 'undefined') {
+      // If we don't have one or the other, make a query out to Djatoka.
+      if (typeof page.width == 'undefined' || typeof page.height == 'undefined') {
+        var pid = page.pid;
+        if(typeof pid == 'undefined') {
+          return dimensions;
+        }
+        var url = this.getDimensionsUri(pid);
+        jQuery.ajax({
+          url: url,
+          dataType: 'json',
+          success: function(data, textStatus, jqXHR) {
+            dimensions.width = parseInt(data.width);
+            dimensions.height = parseInt(data.height);
+          },
+          async: false,
+        });
       }
-      var url = this.getDimensionsUri(pid);
-      jQuery.ajax({
-        url: url,
-        dataType: 'json',
-        success: function(data, textStatus, jqXHR) {
-          dimensions.width = parseInt(data.width);
-          dimensions.height = parseInt(data.height);
-        },
-        async: false,
-      });
-    }
-    else {
-      dimensions.width = parseInt(page.width);
-      dimensions.height = parseInt(page.height);
+      else {
+        dimensions.width = parseInt(page.width);
+        dimensions.height = parseInt(page.height);
+      }
     }
 
     return dimensions;

--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -93,7 +93,7 @@ function IslandoraBookReader(settings) {
       // If we don't have one or the other, make a query out to Djatoka.
       if (typeof page.width == 'undefined' || typeof page.height == 'undefined') {
         var pid = page.pid;
-        if(typeof pid == 'undefined') {
+        if (typeof pid == 'undefined') {
           return dimensions;
         }
         var url = this.getDimensionsUri(pid);


### PR DESCRIPTION
"undefined" indicies get passed to
https://github.com/openlibrary/bookreader/blob/master/BookReader/BookReader.js#L1780-L1788
which results in NaN being used as an index...  Which in turn causes much fun...

Have to check the results being defined any time we access something via indicies...
