### PR TITLE
Make the default the same as where it actually gets used.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -34,7 +34,7 @@ function islandora_internet_archive_bookreader_admin_settings_form(array $form, 
       '#type' => 'textfield',
       '#title' => t('Solr field relating pages to book PIDs'),
       '#description' => t("BookReader needs to know the PID of any book it's searching in, because OCR datastreams are stored in individual pages and </br>not in the book as a whole. This should therefore be set to the page-object-based Solr field that relates it to its parent book's PID."),
-      '#default_value' => $get_default_value('islandora_internet_archive_bookreader_ocr_filter_field', 'rels.isMemberOf'),
+      '#default_value' => $get_default_value('islandora_internet_archive_bookreader_ocr_filter_field', 'RELS_EXT_isMemberOf_uri_ms'),
     ),
     'islandora_internet_archive_bookreader_overlay_opacity' => array(
       '#type' => 'textfield',


### PR DESCRIPTION
When used in includes/callbacks.inc, it was using a different
field...  This lead to confusion as to why the query was not working,
because the admin page was indicating that it should have been one
value, but another was getting used because there had been none
explicitly set, and so the mismatched defaults made for a bad day.
