### PR TITLE
Windows-compatibility: Backslashes in paths (Internet Archive Book Viewer)

### DIFF
--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -101,8 +101,10 @@ function IslandoraBookReader(settings) {
         var url = this.getDimensionsUri(pid);
         jQuery.ajax({
           url: url,
-          dataType: 'json',
+          dataType: 'string', // Keep it a string so we can massage the data first.
           success: function(data, textStatus, jqXHR) {
+            data = data.replace(/\\/g, '/'); // Backslashes in paths will cause errors. Convert to forwardslashes.
+            data = jQuery.parseJSON(data); // Convert to JSON object.
             dimensions.width = parseInt(data.width);
             dimensions.height = parseInt(data.height);
           },
@@ -287,8 +289,10 @@ function IslandoraBookReader(settings) {
     this.removeSearchResults();
     this.showProgressPopup('<img id="searchmarker" src="'+ this.imagesBaseURL + 'marker_srch-on.png'+'">' + Drupal.t('Search results will appear below ...') + '</img>');
     var that = this;
-    $.ajax({url:url, dataType:'json',
+    $.ajax({url:url, dataType:'string', // Keep it a string so we can massage the data first.
             success: function(data, status, xhr) {
+              data = data.replace(/\\/g, '/'); // Backslashes in paths will cause errors. Convert to forwardslashes.
+              data = jQuery.parseJSON(data); // Convert to JSON object.
               that.BRSearchCallback(data);
             },
             error: function() {


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

This viewer caches the JP2 file in the tomcat temp directory. However, in Windows, the path to this file contains backslashes, which jQuery is mistaking as escaped characters. As a result, the viewer loads, but the JP2 image never loads inside of it. This patch converts all the backslashes in the path to forwardslashes, which fixes the problem.
-  _NOTE 1:_ [OpenSeadragon](https://github.com/Islandora/islandora_openseadragon/pull/27) is experiencing the same problem.
-  _NOTE 2:_ There may be a more efficient way to make this path conversion happen.
