### PR TITLE
Respect the use_backup_dsid setting when getting page URIs

### DIFF
--- a/includes/callback.inc
+++ b/includes/callback.inc
@@ -88,23 +88,23 @@ function islandora_internet_archive_bookreader_search_callback($object_id, $term
  *   The DSID of the object with JP2/JPG datastreams.
  */
 function islandora_internet_archive_bookreader_get_image_uri_callback($object_id) {
-  $tn = 'JP2';
+  $dsid = 'JP2';
   if (variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE)) {
     // TODO: We _think_ that Djatoka won't accept JP2s under 4 kibibytes, but
     // it's unclear if that number is configured, or tied to something, or even
     // if it's correct. We should investigate and make sure it's accurate.
     $jp2 = islandora_datastream_load('JP2', $object_id);
-    $tn = $jp2->size >= 4096 ? 'JP2' : 'JPG';
+    $dsid = $jp2->size >= 4096 ? 'JP2' : 'JPG';
   }
 
   module_load_include('inc', 'islandora', 'includes/authtokens');
   $uri_params = array(
     'absolute' => TRUE,
     'query' => array(
-      'token' => islandora_get_object_token($object_id, $tn, 2),
+      'token' => islandora_get_object_token($object_id, $dsid, 2),
     ),
   );
 
-  echo url("islandora/object/{$object_id}/datastream/$tn/view", $uri_params);
+  echo url("islandora/object/{$object_id}/datastream/$dsid/view", $uri_params);
   drupal_exit();
 }

--- a/includes/callback.inc
+++ b/includes/callback.inc
@@ -88,25 +88,22 @@ function islandora_internet_archive_bookreader_search_callback($object_id, $term
  *   The DSID of the object with JP2/JPG datastreams.
  */
 function islandora_internet_archive_bookreader_get_image_uri_callback($object_id) {
-  $uri_params = array('absolute' => TRUE);
-
-  // TODO: We _think_ that Djatoka won't accept JP2s under 4 kibibytes, but
-  // it's unclear if that number is configured, or tied to something, or even
-  // if it's correct. We should investigate and make sure it's accurate.
-  $jp2 = islandora_datastream_load('JP2', $object_id);
-  $tn = $jp2->size >= 4096 ? 'JP2' : 'JPG';
-
-  // Djatoka accesses as an anonymous user. If it can view objects, we don't
-  // need this token or the slowdown it comes with.
-  $anon_permissions = user_role_permissions(array(
-    DRUPAL_ANONYMOUS_RID => 'anonymous',
-  ));
-  if (!isset($anon_permissions[ISLANDORA_VIEW_OBJECTS])) {
-    module_load_include('inc', 'islandora', 'includes/authtokens');
-    $uri_params['query'] = array(
-      'token' => islandora_get_object_token($object_id, $tn, 2),
-    );
+  $tn = 'JP2';
+  if (variable_get('internet_archive_bookreader_use_backup_dsid', FALSE)) {
+    // TODO: We _think_ that Djatoka won't accept JP2s under 4 kibibytes, but
+    // it's unclear if that number is configured, or tied to something, or even
+    // if it's correct. We should investigate and make sure it's accurate.
+    $jp2 = islandora_datastream_load('JP2', $object_id);
+    $tn = $jp2->size >= 4096 ? 'JP2' : 'JPG';
   }
+
+  module_load_include('inc', 'islandora', 'includes/authtokens');
+  $uri_params = array(
+    'absolute' => TRUE,
+    'query' => array(
+      'token' => islandora_get_object_token($object_id, $tn, 2),
+    ),
+  );
 
   echo url("islandora/object/{$object_id}/datastream/$tn/view", $uri_params);
   drupal_exit();

--- a/includes/callback.inc
+++ b/includes/callback.inc
@@ -89,7 +89,7 @@ function islandora_internet_archive_bookreader_search_callback($object_id, $term
  */
 function islandora_internet_archive_bookreader_get_image_uri_callback($object_id) {
   $tn = 'JP2';
-  if (variable_get('internet_archive_bookreader_use_backup_dsid', FALSE)) {
+  if (variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE)) {
     // TODO: We _think_ that Djatoka won't accept JP2s under 4 kibibytes, but
     // it's unclear if that number is configured, or tied to something, or even
     // if it's correct. We should investigate and make sure it's accurate.

--- a/includes/callback.inc
+++ b/includes/callback.inc
@@ -88,27 +88,26 @@ function islandora_internet_archive_bookreader_search_callback($object_id, $term
  *   The DSID of the object with JP2/JPG datastreams.
  */
 function islandora_internet_archive_bookreader_get_image_uri_callback($object_id) {
-  module_load_include('inc', 'islandora', 'includes/authtokens');
-  $jp2 = islandora_datastream_load('JP2', $object_id);
+  $uri_params = array('absolute' => TRUE);
+
   // TODO: We _think_ that Djatoka won't accept JP2s under 4 kibibytes, but
   // it's unclear if that number is configured, or tied to something, or even
   // if it's correct. We should investigate and make sure it's accurate.
-  if ($jp2->size >= 4096) {
-    $uri = url("islandora/object/{$object_id}/datastream/JP2/view", array(
-      'absolute' => TRUE,
-      'query' => array(
-        'token' => islandora_get_object_token($object_id, 'JP2', 2),
-      ),
-    ));
+  $jp2 = islandora_datastream_load('JP2', $object_id);
+  $tn = $jp2->size >= 4096 ? 'JP2' : 'JPG';
+
+  // Djatoka accesses as an anonymous user. If it can view objects, we don't
+  // need this token or the slowdown it comes with.
+  $anon_permissions = user_role_permissions(array(
+    DRUPAL_ANONYMOUS_RID => 'anonymous',
+  ));
+  if (!isset($anon_permissions[ISLANDORA_VIEW_OBJECTS])) {
+    module_load_include('inc', 'islandora', 'includes/authtokens');
+    $uri_params['query'] = array(
+      'token' => islandora_get_object_token($object_id, $tn, 2),
+    );
   }
-  else {
-    $uri = url("islandora/object/{$object_id}/datastream/JPG/view", array(
-      'absolute' => TRUE,
-      'query' => array(
-        'token' => islandora_get_object_token($object_id, 'JPG', 2),
-      ),
-    ));
-  }
-  echo $uri;
+
+  echo url("islandora/object/{$object_id}/datastream/$tn/view", $uri_params);
   drupal_exit();
 }


### PR DESCRIPTION
# What does this Pull Request do?

Small fix to make it only make the backup datastream check if we need to. This spares us an islandora_datastream_load in cases where that isn't set.

I also cleaned up the function by applying the DSID to a variable, which is why the diff is all weird.
# How should this be tested?

It should be tested that with and without the use_backup_dsids checkbox checked, pages load as expected in the IA bookreader. 
# Additional Notes:
- **Does this change require documentation to be updated?** Naaaah
- **Does this change add any new dependencies?** Nope
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** Noooooo
- **Could this change impact execution of existing code?** I certainly hope it does; we should be executing less of it in most cases.

**Tagging:** 
@jordandukart who maintains this thingy

---

QA Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
