### PR TITLE
7.x islandora internet archive bookreader 1880

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: php
 php:
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ before_install:
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_internet_archive_bookreader
   - ln -s $HOME/islandora_paged_content sites/all/modules/islandora_paged_content
   - drush en --yes islandora_internet_archive_bookreader
+before_script:
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - ant -buildfile sites/all/modules/islandora_internet_archive_bookreader/build.xml lint
   # XXX: Move the 3rd-party library stuff out of the way, so it doesn't

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,3 @@ script:
   # XXX: Move the 3rd-party library stuff back in, for tests.
   - mv $HOME/js $TRAVIS_BUILD_DIR
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_internet_archive_bookreader
-  - drush test-run --uri=http://localhost:8081 "Islandora Internet Archive Bookreader"


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Remove Travis-CI Drupal Test invocations made via Drush, which are being deprecated, as there are no tests in this repository. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Removed the from Drush test runner script fro .travis.yml file. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers