### PR TITLE
ISLANDORA-2004: Makes use of new display aiding predicates

### DIFF
--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -20,6 +20,7 @@
     this.fullscreen = false;
     this.content_type = settings.content_type;
     this.pageProgression = settings.pageProgression;
+    this.hasCover = settings.hasCover;
   }
 
   // Inherit from Internet Archive BookReader class.
@@ -112,19 +113,31 @@
       // If pageProgression is not set RTL we assume it is LTR
       if (0 == (index & 0x1)) {
         // Even-numbered page
+        if (false === this.hasCover) {
+          return 'L';
+        }
         return 'R';
       }
       else {
         // Odd-numbered page
+         if (false === this.hasCover) {
+          return 'R';
+        }
         return 'L';
       }
     }
     else {
       // RTL
       if (0 == (index & 0x1)) {
+       if (false === this.hasCover) {
+          return 'R';
+        }
         return 'L';
       }
       else {
+        if (false === this.hasCover) {
+          return 'L';
+        }
         return 'R';
       }
     }

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -10,6 +10,7 @@
  */
 function template_preprocess_islandora_internet_archive_bookreader(array &$variables) {
   module_load_include('inc', 'islandora_internet_archive_bookreader', 'includes/utilities');
+  module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
   module_load_include('inc', 'islandora', 'includes/authtokens');
   $object = $variables['object'];
   $dsid = $variables['datastream_id'];
@@ -17,12 +18,22 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
   $colorbox_path = libraries_get_path('colorbox');
   $module_path = drupal_get_path('module', 'islandora_internet_archive_bookreader');
   $search_uri = module_exists('islandora_solr') ? url("internet_archive_bookreader_search/{$object->id}/TERM", array('absolute' => TRUE)) : NULL;
+  $perbook_view_mode = islandora_paged_content_get_viewing_hint($object);
+
+  if (isset($perbook_view_mode)) {
+    $view_mode = $perbook_view_mode == 'paged' ? 2 : 1;
+  }
+  else {
+    // Defaults to global viewer config.
+    $view_mode = (int) variable_get('islandora_internet_archive_bookreader_default_page_view', 1);
+  }
+  $hascover = islandora_paged_content_get_hascover($object) == 'true' ? TRUE : FALSE;
   $page_source = variable_get('islandora_internet_archive_bookreader_pagesource', 'djatoka');
   $page_source_settings = array();
+  $pages = array();
 
   if ($page_source == 'djatoka') {
     $backup_uris = variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE);
-    $pages = array();
     foreach ($variables['pages'] as $page_pid => $info) {
       $addendum = $backup_uris ? array('pid' => $page_pid) : array(
         'uri' => url("islandora/object/{$page_pid}/datastream/{$dsid}/view", array(
@@ -47,7 +58,6 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
   elseif ($page_source == 'iiif') {
     $identifier_string = variable_get('islandora_internet_archive_bookreader_iiif_identifier', '[islandora_iareader:url_token]');
     $iiif_url = file_create_url(rtrim(variable_get('islandora_internet_archive_bookreader_iiif_url', 'iiif'), '/'));
-    $pages = array();
     foreach ($variables['pages'] as $page_pid => $info) {
       $page_info = array(
         'pid' => $page_pid,
@@ -77,9 +87,10 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
       'imagesFolderUri' => url("$base_url/$library_path/BookReader/images/", array('absolute' => TRUE, 'external' => TRUE)),
       'pageProgression' => $variables['page_progression'],
       'overlayOpacity' => variable_get('islandora_internet_archive_bookreader_overlay_opacity', '0.5'),
-      'mode' => (int) variable_get('islandora_internet_archive_bookreader_default_page_view', 1),
+      'mode' => $view_mode,
       'mobilize' => variable_get('islandora_internet_archive_bookreader_mobile_full_screen', FALSE),
       'content_type' => variable_get('islandora_internet_archive_bookreader_content_type', 'book'),
+      'hasCover' => $hascover,
     ) + $page_source_settings,
   );
 
@@ -121,8 +132,8 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
     'group' => JS_LIBRARY,
     'weight' => -6,
   ));
-  // Use a newer version of color box as the version bundled with BookReader
-  // won't work with JQuery 1.4.4
+  // Use a newer version of color box as the version bundled with BookReader.
+  // Won't work with JQuery 1.4.4.
   drupal_add_js("$colorbox_path/jquery.colorbox-min.js", array(
     'group' => JS_LIBRARY,
     'weight' => -6,
@@ -191,7 +202,7 @@ function theme_islandora_internet_archive_bookreader_book_info(array $variables)
   }
   else {
     $fields = islandora_internet_archive_bookreader_info_fields($object);
-    $convert_to_string = function($o) {
+    $convert_to_string = function ($o) {
       return implode('<br/>', $o);
     };
     $fields = array_map($convert_to_string, $fields);
@@ -203,7 +214,8 @@ function theme_islandora_internet_archive_bookreader_book_info(array $variables)
       'colgroups' => array(),
       'header' => array(t('Field'), t('Values')),
       'rows' => $rows,
-      'sticky' => FALSE));
+      'sticky' => FALSE,
+    ));
   }
   return $content;
 }
@@ -244,12 +256,12 @@ function islandora_internet_archive_bookreader_info_fields(AbstractObject $objec
   );
   $xml = simplexml_load_string($object['MODS']->content);
   $xml->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
-  $to_string = function($o) {
+  $to_string = function ($o) {
     return (string) $o;
   };
   // Query each context node with the given xpath.
   $query_each_context = function (array $contexts, $xpath) {
-    $query = function(&$context, $key, $xpath) {
+    $query = function (&$context, $key, $xpath) {
       $context->registerXPathNamespace('mods', 'http://www.loc.gov/mods/v3');
       $context = $context->xpath($xpath);
     };
@@ -260,7 +272,7 @@ function islandora_internet_archive_bookreader_info_fields(AbstractObject $objec
   };
   // Query the given xpath. If the xpath is any array the first value is the
   // xpath for the context node(s) and the second the path to the value fields.
-  $query = function(SimpleXMLElement $xml, $xpath) use(&$query_each_context) {
+  $query = function (SimpleXMLElement $xml, $xpath) use (&$query_each_context) {
     return is_string($xpath) ? $xml->xpath($xpath) : $query_each_context($xml->xpath($xpath[0]), $xpath[1]);
   };
   foreach ($fields as $label => $xpath) {


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/projects/ISLANDORA/issues/ISLANDORA-2004
Requires https://github.com/Islandora/islandora_paged_content/pull/132

# What does this Pull Request do?

Makes use of the 2 new predicates defined by https://github.com/Islandora/islandora_paged_content/pull/132

# What's new?
A simple change in the JS logic allowing for cover less books and per Object sequence display settings, making it possible to have 1-up and 2-up at the same time in a single repository.
Does not, I repeat, does not conflict with existing code, the way objects are displayed if not using the predicates and does not affect the main IA Book reader source code compatibility.

# How should this be tested?
 See https://github.com/Islandora/islandora_paged_content/pull/132

# Interested parties
Book addicts, @Islandora/7-x-1-x-committers, @adam-vessey @jordandukart @rosiel @qadan 