### PR TITLE
Add options for IIIF to IA module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module requires the following modules/libraries:
 * [Islandora Solr Search](https://github.com/Islandora/islandora_solr_search/) (Optional)
 * [Libraries API](https://www.drupal.org/project/libraries)
 * [Colorbox](https://www.drupal.org/project/colorbox)
-
+* [Drupal Token Module](https://www.drupal.org/project/token)
 
 ## Installation
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -69,7 +69,7 @@ function islandora_internet_archive_bookreader_admin_settings_form(array $form, 
         '#suffix' => '</div>',
         '#type' => 'textfield',
         '#title' => t('IIIF Image Server Base URL'),
-        '#default_value' => variable_get('islandora_internet_archive_bookreader_iiif_url', 'ifff'),
+        '#default_value' => variable_get('islandora_internet_archive_bookreader_iiif_url', 'iiif'),
         '#description' => t('The location of the IIIF Image Server.'),
       ),
       'islandora_internet_archive_bookreader_iiif_token_header' => array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -22,12 +22,79 @@ function islandora_internet_archive_bookreader_admin_settings_form(array $form, 
   };
   $solr_enabled = module_exists('islandora_solr');
   $form = array(
-    'islandora_internet_archive_bookreader_compression' => array(
-      '#type' => 'textfield',
-      '#title' => t('djatoka image compression level'),
-      '#description' => t('The level of compression djatoka will use when creating images (usually set at 4 or 5).'),
-      '#element_validate' => array('element_validate_number'),
-      '#default_value' => $get_default_value('islandora_internet_archive_bookreader_compression', '4'),
+    'islandora_internet_archive_bookreader_pagesource' => array(
+      '#type' => 'select',
+      '#title' => t('Image Server'),
+      '#description' => t('Select the image server to use with IA Bookreader'),
+      '#default_value' => variable_get('islandora_internet_archive_bookreader_pagesource', 'djatoka'),
+      '#options' => array(
+        'djatoka' => t('Adore-Djatoka Image Server'),
+        'iiif' => t('IIIF Image Server'),
+      ),
+    ),
+    'djatoka' => array(
+      '#type' => 'fieldset',
+      '#title' => t('Adore Djatoka Image Server Settings'),
+      '#description' => t('<p>Settings for Adore-Djatoka Image Server</p>'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="islandora_internet_archive_bookreader_pagesource"]' => array('value' => 'djatoka'),
+        ),
+      ),
+      'islandora_internet_archive_bookreader_compression' => array(
+        '#type' => 'textfield',
+        '#title' => t('djatoka image compression level'),
+        '#description' => t('The level of compression djatoka will use when creating images (usually set at 4 or 5).'),
+        '#element_validate' => array('element_validate_number'),
+        '#default_value' => $get_default_value('islandora_internet_archive_bookreader_compression', '4'),
+      ),
+      'islandora_internet_archive_bookreader_use_backup_dsid' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Use the JPG datastream as a backup'),
+        '#description' => t('Djatoka will not return JP2s smaller than 4096 bytes; by checking this, the bookreader will run a check and use the JPG datastream instead. NOTE: applying this setting can slow the bookreader down, especially for busy sites or large books. Be sure only to use this if necessary.'),
+        '#default_value' => variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE),
+      ),
+    ),
+    'iiif' => array(
+      '#type' => 'fieldset',
+      '#title' => t('IIIF Image Server Settings'),
+      '#description' => t('Settings for IIIF Image Server'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="islandora_internet_archive_bookreader_pagesource"]' => array('value' => 'iiif'),
+        ),
+      ),
+      'islandora_internet_archive_bookreader_iiif_url' => array(
+        '#prefix' => '<div id="islandora-openseadragon-iiif-path-wrapper">',
+        '#suffix' => '</div>',
+        '#type' => 'textfield',
+        '#title' => t('IIIF Image Server Base URL'),
+        '#default_value' => variable_get('islandora_internet_archive_bookreader_iiif_url', 'ifff'),
+        '#description' => t('The location of the IIIF Image Server.'),
+      ),
+      'islandora_internet_archive_bookreader_iiif_token_header' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Add token as header'),
+        '#default_value' => variable_get('islandora_internet_archive_bookreader_iiif_token_header', FALSE),
+        '#description' => t('Instead of sending the token as a query parameter, it will be sent in the X-ISLANDORA-TOKEN header.'),
+      ),
+      'islandora_internet_archive_bookreader_iiif_identifier' => array(
+        '#type' => 'textfield',
+        '#title' => t('IIIF Identifier'),
+        '#default_value' => variable_get('islandora_internet_archive_bookreader_iiif_identifier', '[islandora_iareader:url_token]'),
+        '#element_validate' => array('token_element_validate'),
+        '#token_types' => array('islandora_iareader'),
+      ),
+      'islandora_internet_archive_bookreader_iiif_token_tree' => array(
+        '#type' => 'fieldset',
+        '#title' => t('Replacement patterns'),
+        '#collapsible' => TRUE,
+        '#collapsed' => TRUE,
+        '#description' => theme('token_tree', array(
+          'token_types' => array('islandora_iareader'),
+          'global_types' => FALSE,
+        )),
+      ),
     ),
     'islandora_internet_archive_bookreader_ocr_filter_field' => array(
       '#access' => $solr_enabled,
@@ -64,12 +131,6 @@ function islandora_internet_archive_bookreader_admin_settings_form(array $form, 
       '#type' => 'checkbox',
       '#title' => t('Force the Internet Archive Bookreader into full screen for mobile users?'),
       '#default_value' => variable_get('islandora_internet_archive_bookreader_mobile_full_screen', FALSE),
-    ),
-    'islandora_internet_archive_bookreader_use_backup_dsid' => array(
-      '#type' => 'checkbox',
-      '#title' => t('Use the JPG datastream as a backup'),
-      '#description' => t('Djatoka will not return JP2s smaller than 4096 bytes; by checking this, the bookreader will run a check and use the JPG datastream instead. NOTE: applying this setting can slow the bookreader down, especially for busy sites or large books. Be sure only to use this if necessary.'),
-      '#default_value' => variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE),
     ),
   );
   return system_settings_form($form);

--- a/islandora_internet_archive_bookreader.info
+++ b/islandora_internet_archive_bookreader.info
@@ -4,5 +4,6 @@ package = Islandora Viewers
 dependencies[] = libraries
 dependencies[] = islandora_paged_content
 dependencies[] = colorbox
+dependencies[] = token
 version = 7.x-dev
 core = 7.x

--- a/islandora_internet_archive_bookreader.install
+++ b/islandora_internet_archive_bookreader.install
@@ -18,6 +18,9 @@ function islandora_internet_archive_bookreader_uninstall() {
     'islandora_internet_archive_bookreader_sequence_number',
     'islandora_internet_archive_bookreader_overlay_opacity',
     'islandora_internet_archive_bookreader_default_page_view',
+    'islandora_internet_archive_bookreader_iiif_url',
+    'islandora_internet_archive_bookreader_iiif_token_header',
+    'islandora_internet_archive_bookreader_iiif_identifier',
   );
   // Delete the Drupal variables defined by this module.
   array_walk($variables, 'variable_del');

--- a/islandora_internet_archive_bookreader.module
+++ b/islandora_internet_archive_bookreader.module
@@ -206,7 +206,7 @@ function islandora_internet_archive_bookreader_tokens($type, $tokens, array $dat
   $dsid = $data['islandora_iareader']['dsid'];
   $token = $data['islandora_iareader']['token'];
 
-  foreach($tokens as $name => $original) {
+  foreach ($tokens as $name => $original) {
     if ($name == 'pid') {
       $replacements[$original] = $pid;
     }

--- a/islandora_internet_archive_bookreader.module
+++ b/islandora_internet_archive_bookreader.module
@@ -151,3 +151,87 @@ function islandora_internet_archive_bookreader_islandora_pageCModel_islandora_so
     }
   }
 }
+
+/**
+ * Implements hook_token_info().
+ */
+function islandora_internet_archive_bookreader_token_info() {
+  $info = array();
+
+  $info['types']['islandora_iareader'] = array(
+    'name' => t('Islandora IA Bookreader'),
+    'description' => t('Tokens for building IIIF identifer in Islandora IA Bookreader.'),
+    'needs-data' => 'islandora_iareader',
+  );
+
+  $info['tokens']['islandora_iareader']['pid'] = array(
+    'name' => t('PID'),
+    'description' => t('The objects PID.'),
+  );
+
+  $info['tokens']['islandora_iareader']['dsid'] = array(
+    'name' => t('DSID'),
+    'description' => t('The objects DSID.'),
+  );
+
+  $info['tokens']['islandora_iareader']['url'] = array(
+    'name' => t('URL'),
+    'description' => t('The URL to the object in Islandora.'),
+  );
+
+  $info['tokens']['islandora_iareader']['url_token'] = array(
+    'name' => t('URL with Token'),
+    'description' => t('The URL to the object in Islandora with token in the query string.'),
+  );
+
+  $info['tokens']['islandora_iareader']['token'] = array(
+    'name' => t('Token'),
+    'description' => t('The token that can be used to access the object in Islandora.'),
+  );
+
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function islandora_internet_archive_bookreader_tokens($type, $tokens, array $data = array(), array $options = array()) {
+  $replacements = array();
+
+  if ($type != 'islandora_iareader' || !isset($data['islandora_iareader'])) {
+    return $replacements;
+  }
+
+  $pid = $data['islandora_iareader']['pid'];
+  $dsid = $data['islandora_iareader']['dsid'];
+  $token = $data['islandora_iareader']['token'];
+
+  foreach($tokens as $name => $original) {
+    if ($name == 'pid') {
+      $replacements[$original] = $pid;
+    }
+    elseif ($name == 'dsid') {
+      $replacements[$original] = $dsid;
+    }
+    elseif ($name == 'token') {
+      $replacements[$original] = $token;
+    }
+    elseif ($name == 'url' || $name == 'url_token') {
+      $options = array(
+        'absolute' => TRUE,
+        'language' => language_default(),
+        'https' => FALSE,
+      );
+
+      if ($name == 'url_token') {
+        $options['query'] = array(
+          'token' => $token,
+        );
+      }
+
+      $replacements[$original] = url("islandora/object/{$pid}/datastream/{$dsid}/view", $options);
+    }
+  }
+
+  return $replacements;
+}

--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -11,13 +11,12 @@
   IslandoraBookReader = function(settings) {
     BookReader.call(this);
     this.settings = settings;
-    this.dimensions = {};
     this.numLeafs = settings.pageCount;
     this.bookTitle = settings.label.substring(0,97) + '...';
     this.bookUrl = document.location.toString();
     this.imagesBaseURL = settings.imagesFolderUri;
     this.logoURL = '';
-    this.mode = settings.mode
+    this.mode = settings.mode;
     this.fullscreen = false;
     this.content_type = settings.content_type;
     this.pageProgression = settings.pageProgression;
@@ -37,7 +36,6 @@
    *   The index of the page.
    */
   IslandoraBookReader.prototype.getPageNum = function(index) {
-
     return index + 1;
   }
 
@@ -80,80 +78,6 @@
   }
 
   /**
-   * For a given "accessible page index" return metadata from Djatoka.
-   *
-   * @param int index
-   *   The index of the page.
-   *
-   * @return object
-   *   An object contatining the following string fields:
-   *   - width: The width of the image in pixels.
-   *   - height: The width of the image in pixels.
-   *   If this function fails the values for each field will be 0.
-   */
-  IslandoraBookReader.prototype.getPageDimensions = function(index) {
-    var dimensions = { width: 0, height: 0 };
-    var page = this.getPage(index);
-    if (typeof page != 'undefined') {
-      // If we don't have one or the other, make a query out to Djatoka.
-      if (typeof page.width == 'undefined' || typeof page.height == 'undefined') {
-        var pid = page.pid;
-        if (typeof pid == 'undefined') {
-          return dimensions;
-        }
-        var url = this.getDimensionsUri(pid);
-        jQuery.ajax({
-          url: url,
-          dataType: 'json',
-          success: function(data, textStatus, jqXHR) {
-            dimensions.width = parseInt(data.width);
-            dimensions.height = parseInt(data.height);
-          },
-          async: false
-        });
-      }
-      else {
-        dimensions.width = parseInt(page.width);
-        dimensions.height = parseInt(page.height);
-      }
-    }
-
-    return dimensions;
-  }
-
-  /**
-   * Gets the width of the given page.
-   *
-   * @param int index
-   *   The index of the page.
-   *
-   * @return int
-   *   The width in pixels of the given page.
-   */
-  IslandoraBookReader.prototype.getPageWidth = function(index) {
-    if (typeof this.dimensions[index] == 'undefined') {
-      this.dimensions[index] = this.getPageDimensions(index);
-    }
-    return this.dimensions[index].width;
-  }
-
-  /**
-   * Gets the height of the given page.
-   *
-   * @param int index
-   *   The index of the page.
-   *
-   * @return int
-   *   The height in pixels of the given page.
-   */
-  IslandoraBookReader.prototype.getPageHeight = function(index) {
-    if (typeof this.dimensions[index] == 'undefined') {
-      this.dimensions[index] = this.getPageDimensions(index);
-    }
-    return this.dimensions[index].height;
-  }
-
-  /**
    * Checks to see if search is enabled.
    *
    * @return boolean
@@ -161,85 +85,6 @@
    */
   IslandoraBookReader.prototype.searchEnabled = function() {
     return this.settings.searchUri != null;
-  }
-
-  /**
-   * Gets the Djatoka URI.
-   *
-   * @param string resource_uri
-   *   The uri to the image Djatoka will use.
-   *
-   * @return string
-   *   The Djatoka URI for the given resource URI.
-   */
-  IslandoraBookReader.prototype.getDjatokaUri = function(resource_uri) {
-    var base_uri = this.settings.djatokaUri;
-    //Do some sanitation on that base uri.
-    //Since it comes from an admin form, let's make sure there's a '/' at the
-    //end of it.
-    if (base_uri.charAt(base_uri.length) != '/') {
-      base_uri += '/';
-    }
-    var params = $.param({
-      'rft_id': resource_uri,
-      'url_ver': 'Z39.88-2004',
-      'svc_id': 'info:lanl-repo/svc/getRegion',
-      'svc_val_fmt': 'info:ofi/fmt:kev:mtx:jpeg2000',
-      'svc.format': 'image/jpeg',
-      'svc.level': this.settings.compression,
-      'svc.rotate': 0
-    });
-    return (base_uri + 'resolver?' + params);
-  };
-
-  /**
-   * Gets the URI to the dimensions callback for the given page.
-   *
-   * @param string pid
-   *   The id of the object containing the resource.
-   *
-   * @return string
-   *   The Dimensions URI of the callback, to be used to fetch the pages
-   *   dimension.
-   */
-  IslandoraBookReader.prototype.getDimensionsUri = function(pid) {
-    var uri = this.settings.dimensionsUri;
-    uri = uri.replace('PID', pid);
-    return uri;
-  };
-
-  /**
-   * Gets URI to the given page resource.
-   *
-   * @param int index
-   *   The index of the page.
-   *
-   * @return string
-   *   The URI
-   */
-  IslandoraBookReader.prototype.getPageURI = function(index, reduce, rotate) {
-    if (typeof this.settings.pages[index] != 'undefined') {
-      // Using backups? Get the image URI via callback and determine whether to
-      // Djatoka-ize it.
-      if (this.settings.useBackupUri == true) {
-        var callback_uri = null;
-        $.ajax({
-          url: this.settings.tokenUri.replace('PID', this.settings.pages[index].pid),
-          async: false,
-          success: function(data, textStatus, jqXHR) {
-            callback_uri = data;
-          }
-        });
-        if (callback_uri.indexOf("datastream/JP2/view") != -1) {
-          return this.getDjatokaUri(callback_uri);
-        }
-        return callback_uri;
-      }
-      // Not using backups? Just Djatoka-ize the page's image URI.
-      else {
-        return this.getDjatokaUri(this.settings.pages[index].uri);
-      }
-    }
   }
 
   /**

--- a/js/islandora_djatoka_book_reader.js
+++ b/js/islandora_djatoka_book_reader.js
@@ -1,0 +1,170 @@
+/**
+ * @file
+ * IslandoraDjatokaBookReader is derived from the Internet Archive BookReader class.
+ */
+
+(function ($) {
+    /**
+     * Constructor
+     */
+    IslandoraDjatokaBookReader = function(settings) {
+        IslandoraBookReader.call(this, settings);
+        this.dimensions = {};
+    }
+
+    // Inherit from base Islandora bookreader class
+    jQuery.extend(IslandoraDjatokaBookReader.prototype, IslandoraBookReader.prototype);
+
+    /**
+     * For a given "accessible page index" return metadata from Djatoka.
+     *
+     * @param int index
+     *   The index of the page.
+     *
+     * @return object
+     *   An object contatining the following string fields:
+     *   - width: The width of the image in pixels.
+     *   - height: The width of the image in pixels.
+     *   If this function fails the values for each field will be 0.
+     */
+    IslandoraDjatokaBookReader.prototype.getPageDimensions = function(index) {
+        var dimensions = { width: 0, height: 0 };
+        var page = this.getPage(index);
+        if (typeof page != 'undefined') {
+            // If we don't have one or the other, make a query out to Djatoka.
+            if (typeof page.width == 'undefined' || typeof page.height == 'undefined') {
+                var pid = page.pid;
+                if (typeof pid == 'undefined') {
+                    return dimensions;
+                }
+                var url = this.getDimensionsUri(pid);
+                jQuery.ajax({
+                    url: url,
+                    dataType: 'json',
+                    success: function(data, textStatus, jqXHR) {
+                        dimensions.width = parseInt(data.width);
+                        dimensions.height = parseInt(data.height);
+                    },
+                    async: false
+                });
+            }
+            else {
+                dimensions.width = parseInt(page.width);
+                dimensions.height = parseInt(page.height);
+            }
+        }
+
+        return dimensions;
+    }
+
+    /**
+     * Gets the width of the given page.
+     *
+     * @param int index
+     *   The index of the page.
+     *
+     * @return int
+     *   The width in pixels of the given page.
+     */
+    IslandoraDjatokaBookReader.prototype.getPageWidth = function(index) {
+        if (typeof this.dimensions[index] == 'undefined') {
+            this.dimensions[index] = this.getPageDimensions(index);
+        }
+        return this.dimensions[index].width;
+    }
+
+    /**
+     * Gets the height of the given page.
+     *
+     * @param int index
+     *   The index of the page.
+     *
+     * @return int
+     *   The height in pixels of the given page.
+     */
+    IslandoraDjatokaBookReader.prototype.getPageHeight = function(index) {
+        if (typeof this.dimensions[index] == 'undefined') {
+            this.dimensions[index] = this.getPageDimensions(index);
+        }
+        return this.dimensions[index].height;
+    }
+
+    /**
+     * Gets the Djatoka URI.
+     *
+     * @param string resource_uri
+     *   The uri to the image Djatoka will use.
+     *
+     * @return string
+     *   The Djatoka URI for the given resource URI.
+     */
+    IslandoraDjatokaBookReader.prototype.getDjatokaUri = function(resource_uri) {
+        var base_uri = this.settings.djatokaUri;
+        //Do some sanitation on that base uri.
+        //Since it comes from an admin form, let's make sure there's a '/' at the
+        //end of it.
+        if (base_uri.charAt(base_uri.length) != '/') {
+            base_uri += '/';
+        }
+        var params = $.param({
+            'rft_id': resource_uri,
+            'url_ver': 'Z39.88-2004',
+            'svc_id': 'info:lanl-repo/svc/getRegion',
+            'svc_val_fmt': 'info:ofi/fmt:kev:mtx:jpeg2000',
+            'svc.format': 'image/jpeg',
+            'svc.level': this.settings.compression,
+            'svc.rotate': 0
+        });
+        return (base_uri + 'resolver?' + params);
+    };
+
+    /**
+     * Gets the URI to the dimensions callback for the given page.
+     *
+     * @param string pid
+     *   The id of the object containing the resource.
+     *
+     * @return string
+     *   The Dimensions URI of the callback, to be used to fetch the pages
+     *   dimension.
+     */
+    IslandoraDjatokaBookReader.prototype.getDimensionsUri = function(pid) {
+        var uri = this.settings.dimensionsUri;
+        uri = uri.replace('PID', pid);
+        return uri;
+    };
+
+    /**
+     * Gets URI to the given page resource.
+     *
+     * @param int index
+     *   The index of the page.
+     *
+     * @return string
+     *   The URI
+     */
+    IslandoraDjatokaBookReader.prototype.getPageURI = function(index, reduce, rotate) {
+        if (typeof this.settings.pages[index] != 'undefined') {
+            // Using backups? Get the image URI via callback and determine whether to
+            // Djatoka-ize it.
+            if (this.settings.useBackupUri == true) {
+                var callback_uri = null;
+                $.ajax({
+                    url: this.settings.tokenUri.replace('PID', this.settings.pages[index].pid),
+                    async: false,
+                    success: function(data, textStatus, jqXHR) {
+                        callback_uri = data;
+                    }
+                });
+                if (callback_uri.indexOf("datastream/JP2/view") != -1) {
+                    return this.getDjatokaUri(callback_uri);
+                }
+                return callback_uri;
+            }
+            // Not using backups? Just Djatoka-ize the page's image URI.
+            else {
+                return this.getDjatokaUri(this.settings.pages[index].uri);
+            }
+        }
+    }
+})(jQuery);

--- a/js/islandora_iiif_book_reader.js
+++ b/js/islandora_iiif_book_reader.js
@@ -127,7 +127,10 @@
     IslandoraIiifBookReader.prototype.getAjaxHeaders = function(index) {
         var page = this.getPage(index);
         if (this.settings.tokenHeader === true && this.loadWithAjax === true) {
-            return {'X-ISLANDORA-TOKEN' : page.token};
+            if (typeof(page) !== 'undefined' && typeof(page.token) !== 'undefined') {
+                return {'X-ISLANDORA-TOKEN' : page.token};
+            }
         }
+        return {};
     };
 })(jQuery);

--- a/js/islandora_iiif_book_reader.js
+++ b/js/islandora_iiif_book_reader.js
@@ -102,6 +102,13 @@
      *   The URI
      */
     IslandoraIiifBookReader.prototype.getPageURI = function(index, reduce, rotate) {
+        if (typeof(reduce) === 'undefined') {
+            reduce = 1;
+        }
+        if (typeof(rotate) === 'undefined') {
+            rotate = 0;
+        }
+
         var page = this.getPage(index);
         if (typeof page !== 'undefined' && typeof page.identifier !== 'undefined') {
             return this.settings.iiifUri + '/' + page.identifier + '/full/pct:' + (1.0 / reduce * 100).toFixed(0) + '/' + rotate + '/default.jpg';

--- a/js/islandora_iiif_book_reader.js
+++ b/js/islandora_iiif_book_reader.js
@@ -1,0 +1,126 @@
+/**
+ * @file
+ * IslandoraIiifBookReader is derived from the Internet Archive BookReader class.
+ */
+
+(function ($) {
+    /**
+     * Constructor
+     */
+    IslandoraIiifBookReader = function(settings) {
+        IslandoraBookReader.call(this, settings);
+        this.dimensions = {};
+        if (settings.tokenHeader === true) {
+            this.loadWithAjax = true;
+        }
+    };
+
+    // Inherit from base Islandora bookreader class.
+    jQuery.extend(IslandoraIiifBookReader.prototype, IslandoraBookReader.prototype);
+
+    /**
+     * For a given "accessible page index" return metadata from Djatoka.
+     *
+     * @param index
+     *   The index of the page.
+     *
+     * @return object
+     *   An object containing the following string fields:
+     *   - width: The width of the image in pixels.
+     *   - height: The width of the image in pixels.
+     *   If this function fails the values for each field will be 0.
+     */
+    IslandoraIiifBookReader.prototype.getPageDimensions = function(index) {
+        var dimensions = { width: 0, height: 0 };
+        var page = this.getPage(index);
+
+        if (typeof page !== 'undefined') {
+            if (typeof page.width !== 'undefined' && typeof page.height !== 'undefined') {
+                dimensions.width = parseInt(page.width);
+                dimensions.height = parseInt(page.height);
+            }
+            else if (typeof page.identifier !== 'undefined') {
+                var url = this.settings.iiifUri + '/' + page.identifier + '/info.json';
+                jQuery.ajax({
+                    url: url,
+                    dataType: 'json',
+                    success: function(data, textStatus, jqXHR) {
+                        dimensions.width = data.width;
+                        dimensions.height = data.height;
+                    },
+                    async: false
+                });
+            }
+        }
+
+        return dimensions;
+    };
+
+    /**
+     * Gets the width of the given page.
+     *
+     * @param index
+     *   The index of the page.
+     *
+     * @return int
+     *   The width in pixels of the given page.
+     */
+    IslandoraIiifBookReader.prototype.getPageWidth = function(index) {
+        if (typeof this.dimensions[index] === 'undefined') {
+            this.dimensions[index] = this.getPageDimensions(index);
+        }
+        return this.dimensions[index].width;
+    };
+
+    /**
+     * Gets the height of the given page.
+     *
+     * @param index
+     *   The index of the page.
+     *
+     * @return int
+     *   The height in pixels of the given page.
+     */
+    IslandoraIiifBookReader.prototype.getPageHeight = function(index) {
+        if (typeof this.dimensions[index] === 'undefined') {
+            this.dimensions[index] = this.getPageDimensions(index);
+        }
+        return this.dimensions[index].height;
+    };
+
+    /**
+     * Gets URI to the given page resource.
+     *
+     * @param index
+     *   The index of the page.
+     * @param reduce
+     *   The factor by which the image should be reduced
+     * @param rotate
+     *   The amount the image should be rotated.
+     *
+     * @return string
+     *   The URI
+     */
+    IslandoraIiifBookReader.prototype.getPageURI = function(index, reduce, rotate) {
+        var page = this.getPage(index);
+        if (typeof page !== 'undefined' && typeof page.identifier !== 'undefined') {
+            return this.settings.iiifUri + '/' + page.identifier + '/full/pct:' + (1.0 / reduce * 100).toFixed(0) + '/' + rotate + '/default.jpg';
+        }
+    };
+
+    /**
+     * Gets the correct headers for the page.
+     *
+     * @param index
+     *   The index of the page.
+     *
+     * @return object
+     *   String -> String mapping of headers
+     */
+    IslandoraIiifBookReader.prototype.getAjaxHeaders = function(index) {
+        var page = this.getPage(index);
+        if (this.settings.tokenHeader === true && this.loadWithAjax === true) {
+            return {'X-ISLANDORA-TOKEN' : page.token};
+        }
+    };
+})(jQuery);

--- a/js/islandora_internet_archive_bookreader.js
+++ b/js/islandora_internet_archive_bookreader.js
@@ -6,14 +6,20 @@
 
 // noConflict is here to allow for compatibility between jQuery 1.5 and jquery 1.7.
 // JS loaded prior to this point in the bookreader requires jQuery 1.5, and further
-// execution requires jQuery 1.7 or higher. 
-// TODO: Figure out what library is the culprate.
+// execution requires jQuery 1.7 or higher.
+// TODO: Figure out what library is the culprit.
 Drupal.settings.islandoraInternetArchiveBookReader_jQuery = jQuery.noConflict(true);
 (function ($) {
   Drupal.behaviors.islandoraInternetArchiveBookReader = {
     attach: function(context, settings) {
       $('.islandora-internet-archive-bookreader', context).once('islandora-bookreader', function () {
-        var bookReader = new IslandoraBookReader(settings.islandoraInternetArchiveBookReader);
+        var bookReader = null;
+        if (settings.islandoraInternetArchiveBookReader.pageSource === 'djatoka') {
+          bookReader = new IslandoraDjatokaBookReader(settings.islandoraInternetArchiveBookReader);
+        }
+        else if (settings.islandoraInternetArchiveBookReader.pageSource === 'iiif') {
+          bookReader = new IslandoraIiifBookReader(settings.islandoraInternetArchiveBookReader);
+        }
         // Initialize and Render the BookReader.
         bookReader.init();
         // Handle page resize, required for full screen.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -17,43 +17,70 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
   $colorbox_path = libraries_get_path('colorbox');
   $module_path = drupal_get_path('module', 'islandora_internet_archive_bookreader');
   $search_uri = module_exists('islandora_solr') ? url("internet_archive_bookreader_search/{$object->id}/TERM", array('absolute' => TRUE)) : NULL;
-  $backup_uris = variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE);
+  $page_source = variable_get('islandora_internet_archive_bookreader_pagesource', 'djatoka');
+  $page_source_settings = array();
 
-  $pages = array();
-  foreach ($variables['pages'] as $page_pid => $info) {
-    $addendum = $backup_uris ? array('pid' => $page_pid) : array(
-      'uri' => url("islandora/object/{$page_pid}/datastream/{$dsid}/view", array(
-        'absolute' => TRUE,
-        'query' => array(
-          'token' => islandora_get_object_token($page_pid, $dsid, 2),
-        ),
-      )),
+  if ($page_source == 'djatoka') {
+    $backup_uris = variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE);
+    $pages = array();
+    foreach ($variables['pages'] as $page_pid => $info) {
+      $addendum = $backup_uris ? array('pid' => $page_pid) : array(
+        'uri' => url("islandora/object/{$page_pid}/datastream/{$dsid}/view", array(
+          'absolute' => TRUE,
+          'query' => array(
+            'token' => islandora_get_object_token($page_pid, $dsid, 2),
+          ),
+        )),
+      );
+      $pages[] = $info + $addendum;
+    }
+    $page_source_settings = array(
+      'tokenUri' => url('internet_archive_bookreader_get_image_uri/PID', array('absolute' => TRUE)),
+      'dimensionsUri' => url('internet_archive_bookreader_dimensions/PID', array('absolute' => TRUE)),
+      'djatokaUri' => variable_get('islandora_paged_content_djatoka_url', 'http://localhost:8080/adore-djatoka'),
+      'compression' => variable_get('islandora_internet_archive_bookreader_compression', '4'),
+      'pages' => $pages,
+      'pageCount' => count($pages),
+      'useBackupUri' => $backup_uris,
     );
-    $pages[] = $info + $addendum;
+  }
+  elseif ($page_source == 'iiif') {
+    $identifier_string = variable_get('islandora_internet_archive_bookreader_iiif_identifier', '[islandora_iareader:url_token]');
+    $iiifUrl = file_create_url(rtrim(variable_get('islandora_internet_archive_bookreader_iiif_url', 'ifff'),'/'));
+    $pages = array();
+    foreach ($variables['pages'] as $page_pid => $info) {
+      $page_info = array(
+        'pid' => $page_pid,
+        'dsid' => $dsid,
+        'token' => islandora_get_object_token($page_pid, $dsid, 2),
+      );
+      $identifier = token_replace($identifier_string, array('islandora_iareader' => $page_info));
+      $pages[] = $info + $page_info + array('identifier' => urlencode($identifier));
+    }
+    $page_source_settings = array(
+      'iiifUri' => $iiifUrl,
+      'pages' => $pages,
+      'pageCount' => count($pages),
+      'tokenHeader' => (bool)variable_get('islandora_internet_archive_bookreader_iiif_token_header', FALSE),
+    );
   }
 
   global $base_url;
   $data_array = array(
     'islandoraInternetArchiveBookReader' => array(
+      'pageSource' => $page_source,
       'book' => $object->id,
       'info' => theme('islandora_internet_archive_bookreader_book_info', array('object' => $object)),
       'label' => $object->label,
       'searchUri' => $search_uri,
       'textUri' => url('internet_archive_bookreader_text/PID', array('absolute' => TRUE)),
-      'dimensionsUri' => url('internet_archive_bookreader_dimensions/PID', array('absolute' => TRUE)),
-      'tokenUri' => url('internet_archive_bookreader_get_image_uri/PID', array('absolute' => TRUE)),
-      'djatokaUri' => variable_get('islandora_paged_content_djatoka_url', 'http://localhost:8080/adore-djatoka'),
       'imagesFolderUri' => url("$base_url/$library_path/BookReader/images/", array('absolute' => TRUE, 'external' => TRUE)),
-      'compression' => variable_get('islandora_internet_archive_bookreader_compression', '4'),
       'pageProgression' => $variables['page_progression'],
-      'pages' => $pages,
-      'pageCount' => count($pages),
       'overlayOpacity' => variable_get('islandora_internet_archive_bookreader_overlay_opacity', '0.5'),
       'mode' => (int) variable_get('islandora_internet_archive_bookreader_default_page_view', 1),
       'mobilize' => variable_get('islandora_internet_archive_bookreader_mobile_full_screen', FALSE),
       'content_type' => variable_get('islandora_internet_archive_bookreader_content_type', 'book'),
-      'useBackupUri' => $backup_uris,
-    ),
+    ) + $page_source_settings,
   );
 
   drupal_add_js($data_array, 'setting');
@@ -114,6 +141,22 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
       'weight' => -4,
     )
   );
+  if ($page_source == 'djatoka') {
+    drupal_add_js("$module_path/js/islandora_djatoka_book_reader.js",
+      array(
+        'group' => JS_LIBRARY,
+        'weight' => -4,
+      )
+    );
+  }
+  elseif ($page_source == 'iiif') {
+    drupal_add_js("$module_path/js/islandora_iiif_book_reader.js",
+      array(
+        'group' => JS_LIBRARY,
+        'weight' => -4,
+      )
+    );
+  }
   drupal_add_js("$module_path/js/islandora_internet_archive_bookreader.js", array(
     'group' => JS_LIBRARY,
     'weight' => -3,

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -46,7 +46,7 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
   }
   elseif ($page_source == 'iiif') {
     $identifier_string = variable_get('islandora_internet_archive_bookreader_iiif_identifier', '[islandora_iareader:url_token]');
-    $iiif_url = file_create_url(rtrim(variable_get('islandora_internet_archive_bookreader_iiif_url', 'ifff'), '/'));
+    $iiif_url = file_create_url(rtrim(variable_get('islandora_internet_archive_bookreader_iiif_url', 'iiif'), '/'));
     $pages = array();
     foreach ($variables['pages'] as $page_pid => $info) {
       $page_info = array(

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -46,7 +46,7 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
   }
   elseif ($page_source == 'iiif') {
     $identifier_string = variable_get('islandora_internet_archive_bookreader_iiif_identifier', '[islandora_iareader:url_token]');
-    $iiifUrl = file_create_url(rtrim(variable_get('islandora_internet_archive_bookreader_iiif_url', 'ifff'),'/'));
+    $iiif_url = file_create_url(rtrim(variable_get('islandora_internet_archive_bookreader_iiif_url', 'ifff'), '/'));
     $pages = array();
     foreach ($variables['pages'] as $page_pid => $info) {
       $page_info = array(
@@ -58,10 +58,10 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
       $pages[] = $info + $page_info + array('identifier' => urlencode($identifier));
     }
     $page_source_settings = array(
-      'iiifUri' => $iiifUrl,
+      'iiifUri' => $iiif_url,
       'pages' => $pages,
       'pageCount' => count($pages),
-      'tokenHeader' => (bool)variable_get('islandora_internet_archive_bookreader_iiif_token_header', FALSE),
+      'tokenHeader' => (bool) variable_get('islandora_internet_archive_bookreader_iiif_token_header', FALSE),
     );
   }
 


### PR DESCRIPTION
## JIRA Ticket

[ISLANDORA-2100](https://jira.duraspace.org/browse/ISLANDORA-2100)

Blocked by: 
https://github.com/Islandora/internet_archive_bookreader/pull/8

Related to: 
https://github.com/Islandora/islandora_openseadragon/pull/90

## What does this Pull Request do?

This ticket aim is to let the IA Reader use a IIIF server as the source for its tiles. It also adds very similar IIIF server options as are made available in [Islandora OpenSeadragon](https://github.com/Islandora/islandora_openseadragon) in this PR: https://github.com/Islandora/islandora_openseadragon/pull/90.

The idea being that with a combination of this PR and the PR for OpenSeadragon that djtoka could be replaced in the stack with an alternate IIIF image server like [Cantaloupe 🍈](https://medusa-project.github.io/cantaloupe/).

## What's new?

* The javascript object `IslandoraBookReader` has been turned into a base class with `IslandoraIiifBookReader` and `IslandoraDjatokaBookReader` being the concrete object that are created to talk to either Djatoka or IIIF image servers.
* Add a new dependancy for this module on the `token` module for templating.
* Adds configuration to allow IIIF users:
  * to configure the IIIF server base URL
  * to configure the identifier
  * to send the token in a header
    * this allows us to continue to use tokens if desired while not breaking caching.

## How should this be tested?

* Make sure that images using the djatoka source continue to load as before.
* Test that when using IIIF
  * Setting an identifier changes the identifier that IA Reader requests
  * Setting the header feature the header is correctly sent to the IIIF server

The IIIF tests can be accomplished by using the browser inspector to look at the network requests if no IIIF server is available. The header will not be sent to the IIIF server until https://github.com/Islandora/internet_archive_bookreader/pull/8 is merged.

## Additional Notes:

* Does this change add any new dependencies? 
  * Yes it adds a new dependancy on `token`
* Does this change require changes to documentation? 
  * Yes, the new IIIF options will need to be documented.

## Interested parties 
@qadan @Islandora/7-x-1-x-committers