### PR TITLE
7.x islandora 2129

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Set the 'djatoka image compression level', 'Solr field relating pages to book PI
 
 ![Configuration](https://cloud.githubusercontent.com/assets/10052068/24043645/fce70382-0aed-11e7-9e70-11678aa7d1df.png)
 
+The settings for the Internet Archive Book Reader can be altered on a case by case basis via a `hook_preprocess_islandora_internet_archive_bookreader(&$variables)` function.
+
+The array of settings is available in `$variables['settings']` and the array elements are available [here](https://github.com/uml-digitalinitiatives/islandora_internet_archive_bookreader/blob/7.x-ISLANDORA-2129/theme/theme.inc#L34-L58)
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Internet+Archive+Bookreader).

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -14,8 +14,6 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
   $object = $variables['object'];
   $dsid = $variables['datastream_id'];
   $library_path = libraries_get_path('bookreader');
-  $colorbox_path = libraries_get_path('colorbox');
-  $module_path = drupal_get_path('module', 'islandora_internet_archive_bookreader');
   $search_uri = module_exists('islandora_solr') ? url("internet_archive_bookreader_search/{$object->id}/TERM", array('absolute' => TRUE)) : NULL;
   $backup_uris = variable_get('islandora_internet_archive_bookreader_use_backup_dsid', FALSE);
 
@@ -43,7 +41,10 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
       'dimensionsUri' => url('internet_archive_bookreader_dimensions/PID', array('absolute' => TRUE)),
       'tokenUri' => url('internet_archive_bookreader_get_image_uri/PID', array('absolute' => TRUE)),
       'djatokaUri' => variable_get('islandora_paged_content_djatoka_url', 'http://localhost:8080/adore-djatoka'),
-      'imagesFolderUri' => url("$base_url/$library_path/BookReader/images/", array('absolute' => TRUE, 'external' => TRUE)),
+      'imagesFolderUri' => url("$base_url/$library_path/BookReader/images/", array(
+        'absolute' => TRUE,
+        'external' => TRUE
+      )),
       'compression' => variable_get('islandora_internet_archive_bookreader_compression', '4'),
       'pageProgression' => $variables['page_progression'],
       'pages' => $pages,
@@ -55,8 +56,18 @@ function template_preprocess_islandora_internet_archive_bookreader(array &$varia
       'useBackupUri' => $backup_uris,
     ),
   );
+  $variables['settings'] = $data_array;
+}
 
-  drupal_add_js($data_array, 'setting');
+function template_process_islandora_internet_archive_bookreader(&$variables) {
+
+  $colorbox_path = libraries_get_path('colorbox');
+  $module_path = drupal_get_path('module', 'islandora_internet_archive_bookreader');
+  $library_path = libraries_get_path('bookreader');
+
+  $settings = $variables['settings'];
+
+  drupal_add_js($settings, 'setting');
   drupal_add_css("$library_path/BookReader/BookReader.css", array(
     'group' => CSS_SYSTEM,
   ));


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2129

# What does this Pull Request do?

We have some cases where it would be nice to set the book viewer to 1 or 2 pages depending on the book. Currently the settings are grabbed and placed in the page directly in the preprocess function.

This changes the steps so the module grabs the default settings in the `template_preprocess...` but does not add them to the page until the `template_process...` function. 

So individual users could now add a `hook_preprocess_islandora_internet_archive_bookreader` function to make changes.

For example, with this PR I did this simple example.
```
function UofM_2_preprocess_islandora_internet_archive_bookreader(&$variables) {
  $object = $variables['object'];
  if ($object->id == 'uofm:1287812') {
    if (isset($variables['settings']['islandoraInternetArchiveBookReader'])) {
      dsm('set to 1page');
      $variables['settings']['islandoraInternetArchiveBookReader']['mode'] = 1;
    }
  }
}
```
Our default is 2 page mode, but for this object I changed it to 1 page. Normally we did this via javascript and the context module. I think this is more flexible.

This mirrors the pattern in `islandora_openseadragon` of [preprocess](https://github.com/Islandora/islandora_openseadragon/blob/7.x/theme/theme.inc#L14) and [process](https://github.com/Islandora/islandora_openseadragon/blob/7.x/theme/theme.inc#L58).

# What's new?
Not a lot, simply splitting the creation of the settings array (`$data_array`) in the preprocess from the `drupal_add_js()` which is now in a process.

# How should this be tested?

See my example theme hook, try something like that or perhaps more.

# Additional Notes:

Example:
* Does this change require documentation to be updated? Already included
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@DiegoPino @jonathangreen 
