### PR TITLE
bugfix for https://github.com/discoverygarden/islandora_solution_pack…

### DIFF
--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -429,7 +429,7 @@
    * Adjust the book viewer required styles in fullscreen.
    */
   IslandoraBookReader.prototype.resetReaderSizeAndStyle = function(height, top) {
-    $('div#book-viewer').css({
+    $('div#book-viewer, .ia-bookreader').css({
       'position': 'fixed',
       'width': '100%',
       'height': height,
@@ -482,7 +482,7 @@
       });
     }
     else {
-      $('div#book-viewer').css({
+      $('div#book-viewer, .ia-bookreader').css({
       'position': 'relative',
       'z-index': '0'
       });
@@ -502,7 +502,7 @@
    */
   IslandoraBookReader.prototype.goFullScreen = function() {
     this.fullscreen = true;
-    $('div#book-viewer').css({
+    $('div#book-viewer, .ia-bookreader').css({
       'position': 'fixed',
       'width': '100%',
       'height': '100%',


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2151

# What does this Pull Request do?
Adds 'ia-bookreader' class to the selector for full screen functionality.
Current functionality remains unchanged, implementations now have the option of defining their viewer wrapper by class and are not constrained to using a div#book-viewer element.

# What's new?
Adds to the selector which returns the wrapper object in full-screen functionality. Currenty the selector was set to exclusively looking for a div with the id 'book-viewer' now the selector will also return elements given the class name 'ia-bookreader'.

# How should this be tested?
Configure manuscripts to view with the IA book viewer. Ingest a manuscript. Full screen button will not work.
Deploy PR, and add the class 'ia-bookreader' to the div with id 'manuscript-viewer'.

