### PR TITLE
Use drupal_is_https for token uri replacement.

### DIFF
--- a/islandora_internet_archive_bookreader.module
+++ b/islandora_internet_archive_bookreader.module
@@ -220,7 +220,7 @@ function islandora_internet_archive_bookreader_tokens($type, $tokens, array $dat
       $options = array(
         'absolute' => TRUE,
         'language' => language_default(),
-        'https' => FALSE,
+        'https' => drupal_is_https(),
       );
 
       if ($name == 'url_token') {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2162
* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

When generating the url of the object by doing [`token_replace`](https://github.com/Islandora/islandora_internet_archive_bookreader/blob/7.x/theme/theme.inc#L57) ensure that if the request is SSL then make the url token built with SSL. Instead of a hard-coded `FALSE` we call [`drupal_is_http()`](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_is_https/7.x) [here](https://github.com/Islandora/islandora_internet_archive_bookreader/blob/7.x/islandora_internet_archive_bookreader.module#L223)

# What's new?

# How should this be tested?

See related PR in OpenSeadragon - https://github.com/Islandora/islandora_openseadragon/pull/92

A machine with Drupal only over HTTPS will not display images because the browser will always try to access the non-SSL side. 

# Additional Notes:
Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@DiegoPino @jonathangreen 
