### PR TITLE
drupal_is_https added in 7.54, so allow for older versions.

### DIFF
--- a/islandora_internet_archive_bookreader.module
+++ b/islandora_internet_archive_bookreader.module
@@ -220,7 +220,10 @@ function islandora_internet_archive_bookreader_tokens($type, $tokens, array $dat
       $options = array(
         'absolute' => TRUE,
         'language' => language_default(),
-        'https' => drupal_is_https(),
+        'https' => (function_exists('drupal_is_https') ?
+          drupal_is_https() :
+          (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on')
+        ),
       );
 
       if ($name == 'url_token') {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2162

# What does this Pull Request do?

Checks for the `drupal_is_https()` function and if it doesn't exist provides identical functionality inline.

https://cgit.drupalcode.org/drupal/tree/includes/bootstrap.inc?h=7.x&id=7.54#n727

# What's new?

# How should this be tested?

If you have drupal 7.53 or older your Drupal site will error out.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@DiegoPino 
