### PR TITLE
Update maintainer for release, change scheme for OL URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Download/clone the [Internet Archive BookReader](https://github.com/Islandora/internet_archive_bookreader.git) to `sites/all/libraries/bookreader`, or run `drush iabookreader-plugin`.
 
-Internet Archive BookReader [Developer documentation](http://openlibrary.org/dev/docs/bookreader)
+Internet Archive BookReader [Developer documentation](https://openlibrary.org/dev/docs/bookreader)
 
 This module requires that you set up Djatoka, please follow the steps outlined at [here](https://wiki.duraspace.org/pages/viewpage.action?pageId=34658947).
 
@@ -53,7 +53,7 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [Daniel Aitken](https://github.com/qadan)
+* [Diego Pino](https://github.com/DiegoPino)
 
 ## Development
 


### PR DESCRIPTION
**JIRA Ticket**: n/a

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Updated the module maintainer (Diego Pino) in accordance with the spreadsheet for release 7.x-1.11 and changed the scheme of the OpenLibrary URL to HTTPS.

# What's new?

- Diego Pino replaces Daniel Aitkan as maintainer of this module
- OpenLibrary uses HTTPS for all of their URLs, so I replaced a HTTP URL with the HTTPS equivalent

# How should this be tested?

n/a

# Additional Notes:

My employer signed and submitted the (C)CLA.

# Interested parties

Former maintainer: @qadan ; new maintainer: @DiegoPino 