### PR TITLE
ISLANDORA-2191:adds islandora_internet_archive_bookreader_pagesource to uninstall, 7.x-1.11 version

### DIFF
--- a/islandora_internet_archive_bookreader.install
+++ b/islandora_internet_archive_bookreader.install
@@ -21,6 +21,7 @@ function islandora_internet_archive_bookreader_uninstall() {
     'islandora_internet_archive_bookreader_iiif_url',
     'islandora_internet_archive_bookreader_iiif_token_header',
     'islandora_internet_archive_bookreader_iiif_identifier',
+    'islandora_internet_archive_bookreader_pagesource',
   );
   // Delete the Drupal variables defined by this module.
   array_walk($variables, 'variable_del');


### PR DESCRIPTION
**JIRA Ticket**: (http://jira.duraspace.org/browse/ISLANDORA-2191)
Release version of #121
# What does this Pull Request do?

Tiny task. Still, this file serves as documentation of available
vars so important to update.

# What's new?
Nothing (as in no variable left if uninstalled 😄 ).

# How should this be tested?

Install/Uninstall and see that islandora_internet_archive_bookreader_pagesource is not longer there
Or, trust that the uninstall hook will do its work and islandora_internet_archive_bookreader_pagesource is the right name

# Additional Notes:

* Does this change require documentation to be updated? 
NO
* Does this change add any new dependencies? 
NO
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
NO
* Could this change impact execution of existing code?
NO

# Interested parties
@Islandora/7-x-1-x-committers @jonathangreen  @rosiel 