### PR TITLE
Updated link to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This module requires that you set up either Djatoka or an IIIF Image API complia
 
 This module requires [Colorbox](https://www.drupal.org/project/colorbox) and its dependant library [Colorbox library](http://www.jacklmoore.com/colorbox/). Depending on the version of the Colorbox module and library you are using, there can be some issues with Colorbox finding the library. [This](https://www.drupal.org/node/1074474#comment-9137159) comment solves the issue.
 
-Note: If you use the Drush command, it is advisable to Move (not copy) the [install script](https://github.com/islandora/islandora_internet_archive_bookreader/blob/7.x-1.11/islandora_internet_archive_bookreader.drush.inc) to your `.drush` folder before running it.
+Note: If you use the Drush command, it is advisable to Move (not copy) the [install script](https://github.com/islandora/islandora_internet_archive_bookreader/blob/7.x-1.13/islandora_internet_archive_bookreader.drush.inc) to your `.drush` folder before running it.
 
 ## Configuration
 


### PR DESCRIPTION
Link on drush insall script was on version 1.11, fixed to version 1.13.
Note for IIIF config:
On 1.13 test VM configuration of IIIF work with this parameters:
IIIF Image Server Base URL set to: iiif/2
IIIF Identifier: `[islandora_iareader:pid]~[islandora_iareader:dsid]~[islandora_iareader:token]`
Image for this configuration is here https://github.com/DigitLib/wiki-images/blob/master/iiif-conf.jpg



# What does this Pull Request do?

Fix link to drush install script

# What's new?
Changed version from 7.x-1.11 to 7.x-1.13 which install IA BookReader 2.0.2.


# Additional Notes:
Note for IIIF config:
On 1.13 test VM configuration of IIIF work with this parameters:
IIIF Image Server Base URL set to: iiif/2
IIIF Identifier: `[islandora_iareader:pid]~[islandora_iareader:dsid]~[islandora_iareader:token]`
Image for this configuration is here https://github.com/DigitLib/wiki-images/blob/master/iiif-conf.jpg



# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
